### PR TITLE
Quasiquoter for Field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       name: Cache ~/.cabal/store
       with:
         path: ~/.cabal/store
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}-
 
     - name: Installing dependencies 
       run: nix-shell --pure -I ${{ env.NIX_PATH }} --argstr ghcVersion ${{env.GHC}} --run 'make deps' .github/workflows/shell.nix

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 dist-newstyle
 .hie
-cabal.project.local
+cabal.project.local*
 Session.vim
 docs/site
 .hspec-failures

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Session.vim
 docs/site
 .hspec-failures
 <
+.nvimrc

--- a/pg-entity.cabal
+++ b/pg-entity.cabal
@@ -12,6 +12,7 @@ maintainer:       Théophile Choutri
 category:         Database
 license:          MIT
 build-type:       Simple
+tested-with:      GHC ==8.8.4 || ==8.10.7 || ==9.0.1
 extra-source-files:
     CHANGELOG.md
     LICENSE.md
@@ -77,6 +78,7 @@ library
     Database.PostgreSQL.Entity.DBT.Types
     Database.PostgreSQL.Entity.Internal
     Database.PostgreSQL.Entity.Internal.BlogPost
+    Database.PostgreSQL.Entity.QQ
     Database.PostgreSQL.Entity.Types
   hs-source-dirs:
       src
@@ -89,9 +91,11 @@ library
     , postgresql-simple ^>= 0.6
     , resource-pool     ^>= 0.2
     , exceptions        ^>= 0.10
+    , parsec            ^>= 3.1.14.0
     , safe-exceptions   ^>= 0.1
     , text              ^>= 1.2
     , text-manipulate   ^>= 0.3
+    , template-haskell   >= 2.15.0.0 && <= 2.17.0.0
     , time              ^>= 1.9
     , uuid              ^>= 1.3
     , vector            ^>= 0.12

--- a/pg-entity.cabal
+++ b/pg-entity.cabal
@@ -80,6 +80,7 @@ library
     Database.PostgreSQL.Entity.Internal.BlogPost
     Database.PostgreSQL.Entity.QQ
     Database.PostgreSQL.Entity.Types
+    Database.PostgreSQL.Entity.Types.Unsafe
   hs-source-dirs:
       src
   build-depends:

--- a/src/Database/PostgreSQL/Entity.hs
+++ b/src/Database/PostgreSQL/Entity.hs
@@ -106,9 +106,6 @@ selectById value = selectOneByField (primaryKey @e) value
 
 -- | Select precisely __one__ entity by a provided field.
 --
--- ⚠ This function will throw a 'FormatError' exception if an empty string is passed
--- as 'Field'.
---
 -- @since 0.0.1.0
 selectOneByField :: forall e value m.
                  (Entity e, FromRow e, MonadIO m, ToRow value)
@@ -116,9 +113,6 @@ selectOneByField :: forall e value m.
 selectOneByField f value = queryOne Select (_selectWhere @e [f]) value
 
 -- | Select potentially many entities by a provided field.
---
--- ⚠ This function will throw a 'FormatError' exception if an empty string is passed
--- as 'Field'.
 --
 -- @since 0.0.1.0
 selectManyByField :: forall e value m.
@@ -169,9 +163,6 @@ insert fs = void $ execute Insert (_insert @e) fs
 --
 -- > let newAuthor = oldAuthor{…}
 -- > update @Author newAuthor
---
--- ⚠ This function will throw a 'FormatError' exception if an empty string is passed
--- as 'Field'.
 --
 -- @since 0.0.1.0
 update :: forall e newValue m.
@@ -249,9 +240,6 @@ _selectWithFields fs = textToQuery $ "SELECT " <> expandQualifiedFields' fs tn <
 -- The 'Entity' constraint is required for '_where' in order to get any type annotation that was given in the schema, as well as to
 -- filter out unexisting fields.
 --
--- ⚠ This function will throw a 'FormatError' exception if an empty string is passed
--- as 'Field'.
---
 -- __Examples__
 --
 -- >>> _select @BlogPost <> _where @BlogPost ["blogpost_id"]
@@ -269,9 +257,6 @@ _where fs' = textToQuery $ " WHERE " <> clauseFields
     clauseFields = fold $ intercalateVector " AND " (fmap placeholder fs)
 
 -- | Produce a SELECT statement for a given entity and fields.
---
--- ⚠ This function will throw a 'FormatError' exception if an empty string is passed
--- as 'Field'.
 --
 -- __Examples__
 --
@@ -330,9 +315,6 @@ _innerJoin f = textToQuery $ " INNER JOIN " <> getTableName @e
 -- | Produce a "SELECT [table1_fields, table2_fields] FROM table1 INNER JOIN table2 USING(table2_pk)" statement.
 -- The primary is used as the join point between the two tables.
 --
--- ⚠ This function will throw a 'FormatError' exception if an empty string is passed
--- as 'Field'.
---
 -- __Examples__
 --
 -- >>> _joinSelectWithFields @BlogPost @Author ["title"] ["name"]
@@ -381,9 +363,6 @@ _update = _updateBy @e (primaryKey @e)
 
 -- | Produce an UPDATE statement for the given entity by the given field.
 --
--- ⚠ This function will throw a 'FormatError' exception if an empty string is passed
--- as 'Field'.
---
 -- __Examples__
 --
 -- >>> _updateBy @Author "name"
@@ -395,9 +374,6 @@ _updateBy f = _updateFieldsBy @e (fields @e) f
 
 -- | Produce an UPDATE statement for the given entity and fields, by primary key.
 --
--- ⚠ This function will throw a 'FormatError' exception if an empty string is passed
--- as 'Field'.
---
 -- >>> _updateFields @Author ["name"]
 -- "UPDATE \"authors\" SET (\"name\") = ROW(?) WHERE \"author_id\" = ?"
 --
@@ -406,9 +382,6 @@ _updateFields :: forall e. Entity e => Vector Field -> Query
 _updateFields fs = _updateFieldsBy @e fs (primaryKey @e)
 
 -- | Produce an UPDATE statement for the given entity and fields, by the specified field.
---
--- ⚠ This function will throw a 'FormatError' exception if an empty string is passed
--- as 'Field'.
 --
 -- >>> _updateFieldsBy @Author ["name"] "name"
 -- "UPDATE \"authors\" SET (\"name\") = ROW(?) WHERE \"name\" = ?"
@@ -443,9 +416,6 @@ _delete :: forall e. Entity e => Query
 _delete = textToQuery ("DELETE FROM " <> getTableName @e) <> _where @e [primaryKey @e]
 
 -- | Produce a DELETE statement for the given entity and fields
---
--- ⚠ This function will throw a 'FormatError' exception if an empty string is passed
--- as 'Field'.
 --
 -- __Examples__
 --

--- a/src/Database/PostgreSQL/Entity.hs
+++ b/src/Database/PostgreSQL/Entity.hs
@@ -19,8 +19,7 @@ module Database.PostgreSQL.Entity
     Entity (..)
 
     -- * Associated Types
-  , Field (..)
-  , withType
+  , Field
 
     -- * High-level API
     -- $highlevel
@@ -67,7 +66,6 @@ import Control.Monad (void)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Foldable (fold)
 import Data.Int
-import Data.Text (Text)
 import Data.Vector (Vector)
 import qualified Data.Vector as V
 import Database.PostgreSQL.Simple (Only (..))
@@ -87,17 +85,6 @@ import Database.PostgreSQL.Entity.Types
 -- >>> :set -XTypeApplications
 -- >>> import Database.PostgreSQL.Entity
 -- >>> import Database.PostgreSQL.Entity.Internal.BlogPost
-
--- | A infix helper to declare a table field with an explicit type annotation.
---
--- __Examples__
---
--- >>> "author_id" `withType` "uuid[]"
--- Field {fieldName = "author_id", fieldType = Just "uuid[]"}
---
--- @since 0.0.1.0
-withType :: Field -> Text -> Field
-withType (Field n _) t = Field n (Just t)
 
 -- $highlevel
 -- Glossary / Tips’n’Tricks

--- a/src/Database/PostgreSQL/Entity/Internal.hs
+++ b/src/Database/PostgreSQL/Entity/Internal.hs
@@ -38,6 +38,7 @@ import Database.PostgreSQL.Simple.Types (Query (..))
 
 import Data.Foldable (fold)
 import Database.PostgreSQL.Entity.Types
+import Database.PostgreSQL.Entity.Types.Unsafe (Field (Field))
 
 -- $setup
 -- >>> :set -XOverloadedStrings

--- a/src/Database/PostgreSQL/Entity/Internal/BlogPost.hs
+++ b/src/Database/PostgreSQL/Entity/Internal/BlogPost.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE StrictData #-}
 {-|
   Module      : Database.PostgreSQL.Entity.Internal.BlogPost
   Copyright   : © Clément Delafargue, 2018
                   Théophile Choutri, 2021
+                  Koz Ross, 2021
   License     : MIT
   Maintainer  : theophile@choutri.eu
   Stability   : stable
@@ -28,7 +30,8 @@ import GHC.Generics (Generic)
 import GHC.OverloadedLabels (IsLabel (..))
 import GHC.Records (HasField (..))
 
-import Database.PostgreSQL.Entity (insert, withType)
+import Database.PostgreSQL.Entity (insert)
+import Database.PostgreSQL.Entity.QQ (field)
 import Database.PostgreSQL.Entity.Types (Entity (..), GenericEntity, PrimaryKey, TableName)
 
 -- | Wrapper around the UUID type
@@ -78,13 +81,13 @@ instance HasField x BlogPost a => IsLabel x (BlogPost -> a) where
 
 instance Entity BlogPost where
   tableName  = "blogposts"
-  primaryKey = "blogpost_id"
-  fields = [ "blogpost_id"
-           , "author_id"
-           , "uuid_list" `withType` "uuid[]"
-           , "title"
-           , "content"
-           , "created_at"
+  primaryKey = [field| blogpost_id |]
+  fields = [ [field| blogpost_id |]
+           , [field| author_id |]
+           , [field| uuid_list :: uuid[] |]
+           , [field| title |]
+           , [field| content |]
+           , [field| created_at |]
            ]
 
 -- | A specialisation of the 'Database.PostgreSQL.Entity.insert' function.

--- a/src/Database/PostgreSQL/Entity/QQ.hs
+++ b/src/Database/PostgreSQL/Entity/QQ.hs
@@ -21,6 +21,21 @@ import Language.Haskell.TH.Quote (QuasiQuoter (QuasiQuoter))
 import Language.Haskell.TH.Syntax (lift)
 import Text.Parsec (Parsec, anyChar, manyTill, parse, space, spaces, string, try, (<|>))
 
+-- A quasi-quoter for constructing 'Field's.
+--
+--- === __Example:__
+--
+-- > instance Entity BlogPost where
+-- >   tableName  = "blogposts"
+-- >   primaryKey = [field| blogpost_id |]
+-- >   fields = [ [field| blogpost_id |]
+-- >            , [field| author_id |]
+-- >            , [field| uuid_list :: uuid[] |] -- ← This is where we specify an optional PostgreSQL type annotation
+-- >            , [field| title |]
+-- >            , [field| content |]
+-- >            , [field| created_at |]
+-- >            ]
+--
 -- | @since 0.1.0.0
 field :: QuasiQuoter
 field = QuasiQuoter fieldExp errorFieldPat errorFieldType errorFieldDec

--- a/src/Database/PostgreSQL/Entity/QQ.hs
+++ b/src/Database/PostgreSQL/Entity/QQ.hs
@@ -39,7 +39,7 @@ errorFieldPat _ = fail "Cannot use 'field' in a pattern context."
 fieldParser :: Parsec String () (Text, Maybe Text)
 fieldParser = do
   spaces
-  res <- (try withType) <|> noType
+  res <- try withType <|> noType
   spaces
   pure res
   where

--- a/src/Database/PostgreSQL/Entity/QQ.hs
+++ b/src/Database/PostgreSQL/Entity/QQ.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+{-|
+ Module     : Database.PostgreSQL.Entity.QQ
+ Copyright  : © Koz Ross, 2021
+ License    : MIT
+ Maintainer : koz.ross@retro-freedom.nz
+ Stability  : Experimental
+
+ A quasi-quoter for 'Field's, supporting optional types.
+
+ There is little reason to import this module directly; instead, import
+ 'Database.PostgreSQL.Entity', which re-exports the 'field' quasiquoter.
+-}
+module Database.PostgreSQL.Entity.QQ (field) where
+
+import Data.Text (Text, pack)
+import Database.PostgreSQL.Entity.Types (Field (Field))
+import Language.Haskell.TH (Dec, Exp, Pat, Q, Type)
+import Language.Haskell.TH.Quote (QuasiQuoter (QuasiQuoter))
+import Language.Haskell.TH.Syntax (lift)
+import Text.Parsec (Parsec, anyChar, manyTill, parse, space, spaces, string, try, (<|>))
+
+-- | @since 0.1.0.0
+field :: QuasiQuoter
+field = QuasiQuoter fieldExp errorFieldPat errorFieldType errorFieldDec
+
+-- Helpers
+
+fieldExp :: String -> Q Exp
+fieldExp input = case parse fieldParser "Expression" input of
+  Left err               -> fail . show $ err
+  Right (name, Nothing)  -> [e| Field $(lift name) Nothing |]
+  Right (name, Just typ) -> [e| Field $(lift name) (Just $(lift typ)) |]
+
+errorFieldPat :: String -> Q Pat
+errorFieldPat _ = fail "Cannot use 'field' in a pattern context."
+
+fieldParser :: Parsec String () (Text, Maybe Text)
+fieldParser = do
+  spaces
+  res <- (try withType) <|> noType
+  spaces
+  pure res
+  where
+    withType :: Parsec String () (Text, Maybe Text)
+    withType = do
+      name <- manyTill anyChar (try space)
+      case name of
+        [] -> fail "Cannot have an empty field name."
+        _ -> do
+          spaces
+          _ <- string "::"
+          spaces
+          typ <- manyTill anyChar (try space)
+          case typ of
+            [] -> fail "Cannot have an empty type."
+            _  -> pure (pack name, Just . pack $ typ)
+    noType :: Parsec String () (Text, Maybe Text)
+    noType = do
+      name <- manyTill anyChar (try space)
+      case name of
+        [] -> fail "Cannot have an empty field name."
+        _  -> pure (pack name, Nothing)
+
+errorFieldType :: String -> Q Type
+errorFieldType _ = fail "Cannot use 'field' in a type context."
+
+errorFieldDec :: String -> Q [Dec]
+errorFieldDec _ = fail "Cannot use 'field' in a declaration context."

--- a/src/Database/PostgreSQL/Entity/QQ.hs
+++ b/src/Database/PostgreSQL/Entity/QQ.hs
@@ -15,7 +15,7 @@
 module Database.PostgreSQL.Entity.QQ (field) where
 
 import Data.Text (Text, pack)
-import Database.PostgreSQL.Entity.Types (Field (Field))
+import Database.PostgreSQL.Entity.Types.Unsafe (Field (Field))
 import Language.Haskell.TH (Dec, Exp, Pat, Q, Type)
 import Language.Haskell.TH.Quote (QuasiQuoter (QuasiQuoter))
 import Language.Haskell.TH.Syntax (lift)

--- a/src/Database/PostgreSQL/Entity/Types.hs
+++ b/src/Database/PostgreSQL/Entity/Types.hs
@@ -35,7 +35,6 @@ module Database.PostgreSQL.Entity.Types
 
 import Data.Kind
 import Data.Proxy
-import Data.String
 import Data.Text (Text, pack)
 import qualified Data.Text.Manipulate as T
 import Data.Vector (Vector)
@@ -214,10 +213,6 @@ data Field
             -- ^ An optional postgresql type for which we need to be explicit, like @Just "uuid[]"@
           }
   deriving stock (Eq, Generic, Show)
-
--- | @since 0.0.1.0
-instance IsString Field where
-  fromString n = Field (pack n) Nothing
 
 -- | Wrapper used by the update function in order to have the primary key as the last parameter passed,
 -- since it appears in the WHERE clause.

--- a/src/Database/PostgreSQL/Entity/Types/Unsafe.hs
+++ b/src/Database/PostgreSQL/Entity/Types/Unsafe.hs
@@ -1,0 +1,35 @@
+{-|
+  Module      : Database.PostgreSQL.Entity.Types.Unsafe
+  Copyright   : © Clément Delafargue, 2018
+                  Théophile Choutri, 2021
+                  Koz Ross, 2021
+  License     : MIT
+  Maintainer  : theophile@choutri.eu
+  Stability   : Experimental
+
+  Contains the internals of several key types.
+
+  = Note
+
+  By using these directly, you run the risk of violating internal invariants,
+  or making representational changes in incompatible ways. This API is not
+  stable, and is not subject to the PVP. Use at your own risk
+
+  If at all possible, instead use the API provided by
+  'Database.PostgreSQL.Entity.Types'.
+
+-}
+module Database.PostgreSQL.Entity.Types.Unsafe
+  (
+    Field (..)
+  ) where
+
+import Data.Text (Text)
+
+-- | A wrapper for table fields.
+--
+-- @since 0.0.1.0
+data Field
+  = Field Text (Maybe Text)
+  deriving stock (Eq, Show)
+

--- a/test/GenericsSpec.hs
+++ b/test/GenericsSpec.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE QuasiQuotes #-}
+
 module GenericsSpec where
 
 import Data.Text
+import Database.PostgreSQL.Entity.QQ (field)
 import Database.PostgreSQL.Entity.Types
 import GHC.Generics
 import Test.Hspec
@@ -27,7 +30,7 @@ spec = describe "Ensure generically-derived instances with no options are correc
   it "TestType has the expected table name" $ do
     tableName @TestType `shouldBe` "test_type"
   it "TestType has the expected field list" $ do
-    fields @TestType `shouldBe` ["field_one", "field_two", "field_three"]
+    fields @TestType `shouldBe` [[field| field_one |], [field| field_two |], [field| field_three |]]
   it "TestType has the expected primary key" $ do
     primaryKey @TestType `shouldBe` Field "field_one" Nothing
   it "Apple has the expected primary key" $ do
@@ -35,4 +38,4 @@ spec = describe "Ensure generically-derived instances with no options are correc
   it "Apple has the expected table name" $ do
     tableName @Apple `shouldBe` "apples"
   it "Apple has the expected fields" $ do
-    fields @Apple `shouldBe` ["this_field", "that_field"]
+    fields @Apple `shouldBe` [[field| this_field |], [field| that_field |]]

--- a/test/GenericsSpec.hs
+++ b/test/GenericsSpec.hs
@@ -6,6 +6,7 @@ module GenericsSpec where
 import Data.Text
 import Database.PostgreSQL.Entity.QQ (field)
 import Database.PostgreSQL.Entity.Types
+import Database.PostgreSQL.Entity.Types.Unsafe (Field (Field))
 import GHC.Generics
 import Test.Hspec
 


### PR DESCRIPTION
This eliminates, by construction, a whole host of errors (and possible exception cases) around people building `Field`s with empty names (or types, for that matter). I've left the `Field` constructor exposed in a new module, but clearly indicated that it's both unsafe and unstable.

On a related question: how do empty _table_ names get handled?