### PR TITLE
Update CI to use latest versions of GHC and Cabal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   cabal:
-    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
+    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }} (${{ matrix.cabal }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        cabal: ["3.4.0.0"]
-        ghc: ["8.8.4", "8.10.4", "9.0.1"]
+        cabal: ["3.4.0.0", "3.6.2.0"]
+        ghc: ["8.8.4", "8.10.7", "9.0.1", "9.2.1"]
 
     steps:
     - uses: actions/checkout@v2
@@ -35,21 +35,23 @@ jobs:
     - name: Configure Darwin Nixpkgs
       if: matrix.os == 'macos-latest' 
       run: |
-        echo 'NIX_PATH="nixpkgs=channel:nixpkgs-21.05-darwin"' >> "$GITHUB_ENV"
+        echo 'NIX_PATH="nixpkgs=channel:nixpkgs-unstable-darwin"' >> "$GITHUB_ENV"
 
     - name: Configure Linux Nixpkgs
       if: matrix.os == 'ubuntu-latest'
       run: |
-        echo 'NIX_PATH="nixpkgs=channel:nixos-21.05"' >> "$GITHUB_ENV"
+        echo 'NIX_PATH="nixpkgs=channel:nixpkgs-unstable"' >> "$GITHUB_ENV"
 
     - name: Set GHC version for Nix
       run: |
         if [[ ${{matrix.ghc}} == '8.8.4' ]]
         then echo "GHC='884'" >> "$GITHUB_ENV"
-        elif [[ ${{matrix.ghc}} == '8.10.4' ]]
-        then echo "GHC='8104'" >> "$GITHUB_ENV"
+        elif [[ ${{matrix.ghc}} == '8.10.7' ]]
+        then echo "GHC='8107'" >> "$GITHUB_ENV"
         elif [[ ${{matrix.ghc}} == '9.0.1' ]]
         then echo "GHC='901'" >> "$GITHUB_ENV"
+        elif [[ ${{matrix.ghc}} == '9.2.1' ]]
+        then echo "GHC='921'" >> "$GITHUB_ENV"
         fi
 
     - name: Install Nix

--- a/.github/workflows/setup_ci_env.sh
+++ b/.github/workflows/setup_ci_env.sh
@@ -7,13 +7,15 @@ CI_OS=$(uname -s)
 install_deps_linux() {
   echo "Setting up the environment for linux"
   sudo apt-get update
-  sudo apt install -y postgresql-13 libpq-dev 
+  sudo apt -y upgrade
+  sudo apt install -y postgresql-12 libpq-dev 
 }
 
 install_deps_darwin() {
   echo "Setting up the environment for macOS"
   brew update
-  brew install postgresql@13
+  brew upgrade
+  brew install postgresql@12
 }
 
 case $CI_OS in

--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: ./
 tests: True
 documentation: True
 
-index-state: 2021-09-02T20:02:58Z
+index-state: 2021-10-31T09:30:28Z

--- a/pg-entity.cabal
+++ b/pg-entity.cabal
@@ -12,7 +12,7 @@ maintainer:       Théophile Choutri
 category:         Database
 license:          MIT
 build-type:       Simple
-tested-with:      GHC ==8.8.4 || ==8.10.7 || ==9.0.1
+tested-with:      GHC ==8.8.4 || ==8.10.7 || ==9.0.1 || == 9.2.1
 extra-source-files:
     CHANGELOG.md
     LICENSE.md
@@ -83,7 +83,7 @@ library
   hs-source-dirs:
       src
   build-depends:
-    , base               >= 4.12 && <= 4.16
+    , base               >= 4.12 && < 5
     , bytestring        ^>= 0.10
     , colourista        ^>= 0.1
     , monad-control     ^>= 1.0


### PR DESCRIPTION
* [ ] GHC 9.2.1 is available in nixpkgs-unstable
* [x] https://github.com/haskell-infra/hackage-trustees/issues/319 is solved