### PR TITLE
Add the `StripPrefix` modifier to the GenericEntity options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,19 +35,19 @@ jobs:
     - name: Configure Darwin Nixpkgs
       if: matrix.os == 'macos-latest' 
       run: |
-        echo 'NIX_PATH="nixpkgs=channel:nixpkgs-21.05-darwin"' >> "$GITHUB_ENV"
+        echo 'NIX_PATH="nixpkgs=channel:nixpkgs-21.11-darwin"' >> "$GITHUB_ENV"
 
     - name: Configure Linux Nixpkgs
       if: matrix.os == 'ubuntu-latest'
       run: |
-        echo 'NIX_PATH="nixpkgs=channel:nixos-21.05"' >> "$GITHUB_ENV"
+        echo 'NIX_PATH="nixpkgs=channel:nixos-21.11"' >> "$GITHUB_ENV"
 
     - name: Set GHC version for Nix
       run: |
         if [[ ${{matrix.ghc}} == '8.8.4' ]]
         then echo "GHC='884'" >> "$GITHUB_ENV"
         elif [[ ${{matrix.ghc}} == '8.10.4' ]]
-        then echo "GHC='8104'" >> "$GITHUB_ENV"
+        then echo "GHC='8107'" >> "$GITHUB_ENV"
         elif [[ ${{matrix.ghc}} == '9.0.1' ]]
         then echo "GHC='901'" >> "$GITHUB_ENV"
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         cabal: ["3.4.0.0"]
-        ghc: ["8.8.4", "8.10.4", "9.0.1"]
+        ghc: ["8.8.4", "8.10.7", "9.0.1"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         if [[ ${{matrix.ghc}} == '8.8.4' ]]
         then echo "GHC='884'" >> "$GITHUB_ENV"
-        elif [[ ${{matrix.ghc}} == '8.10.4' ]]
+        elif [[ ${{matrix.ghc}} == '8.10.7' ]]
         then echo "GHC='8107'" >> "$GITHUB_ENV"
         elif [[ ${{matrix.ghc}} == '9.0.1' ]]
         then echo "GHC='901'" >> "$GITHUB_ENV"

--- a/.github/workflows/shell.nix
+++ b/.github/workflows/shell.nix
@@ -1,7 +1,7 @@
 { ghcVersion }:
 let pkgs = import <nixpkgs> {};
 in with pkgs;
-  mkShell {
+  mkShell rec {
     buildInputs = [
       # Haskell Deps
       haskell.compiler."ghc${ghcVersion}"
@@ -9,9 +9,10 @@ in with pkgs;
       hlint
       haskellPackages.apply-refact
       stylish-haskell
+      ncurses6
 
       # DB Deps
-      postgresql_12
+      postgresql_14
       gmp
       zlib
       glibcLocales
@@ -23,6 +24,7 @@ in with pkgs;
       gnumake
     ];
     shellHook = ''
+      export LD_LIBRARY_PATH="${lib.makeLibraryPath buildInputs}";
       export LOCALE_ARCHIVE="/nix/store/m53mq2077pfxhqf37gdbj7fkkdc1c8hc-glibc-locales-2.27/lib/locale/locale-archive"
       export LC_ALL=C.UTF-8
     '';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## 0.0.2.0 -- YYYY-mm-dd
 
 * Add `queryOne_`, which takes no params and returns 0 or 1 results.
-
+* Add `FieldModifiers` deriving option, which takes multiple modifiers:
+  * `StripPrefix (prefix :: Symbol)`: You can remove a certain prefix from your field names
+  * `CamelTo (separator :: Symbol)` and its variants, `CamelToSnake` and `CamelToKebab`: Transform field names written
+  in CamelCase to snake\_case, kebab-case, or with a custom separator.
 ## 0.0.1.0 -- 2021-11-05
 
 * First version. Released on an unsuspecting world.

--- a/cabal.project
+++ b/cabal.project
@@ -4,3 +4,10 @@ tests: True
 documentation: True
 
 index-state: 2021-09-02T20:02:58Z
+
+extra-lib-dirs:
+  /usr/pgsql-14/lib
+
+package pg-entity
+  ghc-options:
+    "-L /usr/pgsql-14/lib" 

--- a/cabal.project
+++ b/cabal.project
@@ -11,3 +11,6 @@ extra-lib-dirs:
 package pg-entity
   ghc-options:
     "-L /usr/pgsql-14/lib" 
+  haddock-options:
+    "--optghc=-L /usr/pgsql-14/lib" 
+

--- a/src/Database/PostgreSQL/Entity/DBT.hs
+++ b/src/Database/PostgreSQL/Entity/DBT.hs
@@ -106,7 +106,7 @@ queryOne :: (ToRow params, FromRow result, MonadIO m)
 queryOne queryNature q params = do
   logQueryFormat queryNature q params
   listToMaybe <$> PGT.query q params
-  
+
 --
 -- | Query wrapper that returns one result and does not take an argument
 --
@@ -115,7 +115,7 @@ queryOne_ :: (FromRow result, MonadIO m)
          => QueryNature -> Query -> PGT.DBT m (Maybe result)
 queryOne_ queryNature q = do
   logQueryFormat queryNature q ()
-  listToMaybe <$> PGT.query_ q 
+  listToMaybe <$> PGT.query_ q
 
 -- | Query wrapper for SQL statements which do not return.
 --

--- a/src/Database/PostgreSQL/Entity/Types.hs
+++ b/src/Database/PostgreSQL/Entity/Types.hs
@@ -34,22 +34,28 @@ module Database.PostgreSQL.Entity.Types
   , EntityOptions(..)
   , PrimaryKey
   , TableName
+  , FieldModifiers
+  , TextModifier(..)
   , StripPrefix
+  , CamelTo
+  , CamelToSnake
+  , CamelToKebab
   ) where
 
+import Data.Char
 import Data.Kind
 import Data.Maybe
 import Data.Proxy
 import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Manipulate as T
 import Data.Vector (Vector)
+import qualified Data.Vector as V
 import Database.PostgreSQL.Entity.Internal.QQ (field)
 import Database.PostgreSQL.Entity.Internal.Unsafe (Field (Field))
 import Database.PostgreSQL.Simple.ToRow (ToRow (..))
 import GHC.Generics
 import GHC.TypeLits
-import qualified Data.Text as T
-import qualified Data.Text.Manipulate as T
-import qualified Data.Vector as V
 
 -- | An 'Entity' stores the following information about the structure of a database table:
 --
@@ -82,7 +88,7 @@ class Entity e where
   primaryKey :: Field
   default primaryKey :: (GetFields (Rep e)) => Field
   primaryKey = Field (primMod name) typ
-    where primMod = primaryKeyModifier defaultEntityOptions
+    where primMod = primaryKeyModifiers defaultEntityOptions
           Field name typ = V.head $ getField @(Rep e) defaultEntityOptions
   -- | The fields of the table.
   fields :: Vector Field
@@ -116,9 +122,7 @@ instance GetTableName e => GetTableName (M1 S _1 e) where
 
 instance (KnownSymbol name)
     => GetTableName (M1 D ('MetaData name _1 _2 _3) e) where
-  getTableName Options{tableNameModifier, prefixToStrip} = tableNameModifier $ stripPrefix $ T.pack $ symbolVal (Proxy :: Proxy name)
-    where
-      stripPrefix text = fromMaybe text (T.stripPrefix prefixToStrip text)
+  getTableName Options{tableNameModifiers, fieldModifiers} = tableNameModifiers $ fieldModifiers $ T.pack $ symbolVal (Proxy :: Proxy name)
 
 -- The sub-class that fetches the table fields
 class GetFields (e :: Type -> Type) where
@@ -146,10 +150,9 @@ instance GetFields e => GetFields (M1 D ('MetaData _1 _2 _3 _4) e) where
   getField opts = getField @e opts
 
 instance (KnownSymbol name) => GetFields (M1 S ('MetaSel ('Just name) _1 _2 _3) _4) where
-  getField Options{fieldModifier, prefixToStrip} = V.singleton $ Field fieldName' Nothing
+  getField Options{fieldModifiers} = V.singleton $ Field fieldName' Nothing
     where
-      fieldName' = fieldModifier $ stripPrefix $ T.pack $ symbolVal (Proxy @name)
-      stripPrefix text = fromMaybe text (T.stripPrefix prefixToStrip text)
+      fieldName' = fieldModifiers $ T.pack $ symbolVal (Proxy @name)
 
 -- Deriving Via machinery
 
@@ -160,21 +163,20 @@ instance (EntityOptions t, GetTableName (Rep e), GetFields (Rep e)) => Entity (G
   tableName = getTableName @(Rep e) (entityOptions @t)
 
   primaryKey = Field (primMod name) typ
-    where primMod = primaryKeyModifier defaultEntityOptions
+    where primMod = primaryKeyModifiers defaultEntityOptions
           Field name typ = V.head $ getField @(Rep e) (entityOptions @t)
 
   fields = getField @(Rep e) (entityOptions @t)
 
 -- | Term-level options
 data Options
-  = Options { tableNameModifier  :: Text -> Text
-            , primaryKeyModifier :: Text -> Text
-            , prefixToStrip      :: Text
-            , fieldModifier      :: Text -> Text
+  = Options { tableNameModifiers  :: Text -> Text
+            , primaryKeyModifiers :: Text -> Text
+            , fieldModifiers      :: Text -> Text
             }
 
 defaultEntityOptions :: Options
-defaultEntityOptions = Options T.toSnake T.toSnake "" T.toSnake
+defaultEntityOptions = Options T.toSnake T.toSnake T.toSnake
 
 -- | Type-level options for Deriving Via
 class EntityOptions xs where
@@ -184,19 +186,69 @@ instance EntityOptions '[] where
   entityOptions = defaultEntityOptions
 
 instance (GetName name, EntityOptions xs) => EntityOptions (TableName name ': xs) where
-  entityOptions = (entityOptions @xs){tableNameModifier = const (getName @name)}
+  entityOptions = (entityOptions @xs){tableNameModifiers = const (getName @name)}
 
 instance (GetName name, EntityOptions xs) => EntityOptions (PrimaryKey name ': xs) where
-  entityOptions = (entityOptions @xs){primaryKeyModifier = const (getName @name)}
+  entityOptions = (entityOptions @xs){primaryKeyModifiers = const (getName @name)}
 
-instance (GetName prefix, EntityOptions xs) => EntityOptions (StripPrefix prefix ': xs) where
-  entityOptions = (entityOptions @xs){prefixToStrip = getName @prefix }
+instance (TextModifier mods, EntityOptions xs) => EntityOptions (FieldModifiers mods ': xs) where
+  entityOptions = (entityOptions @xs){fieldModifiers = getTextModifier @mods}
 
 data TableName t
 
 data PrimaryKey t
 
+-- | Contains a list of 'TextModifiers' modifiers
+data FieldModifiers ms
+
+-- | 'TextModifier' to remove a certain prefix from the fields
 data StripPrefix (prefix :: Symbol)
+
+-- | 'FieldModifier' taking a separator Char when transforming from CamelCase.
+data CamelTo (separator :: Symbol)
+
+-- | CamelCase to snake_case
+type CamelToSnake = CamelTo "_"
+
+-- | CamelCase to kebab-case
+type CamelToKebab = CamelTo "-"
+
+-- | The modifiers that you can apply to the fields:
+--
+-- * 'StripPrefix'
+-- * 'CamelTo', and its variations
+--   * 'CamelToSnake'
+--   * 'CamelToKebab'
+class TextModifier t where
+  getTextModifier :: Text -> Text
+
+--  No modifier
+instance TextModifier '[] where
+  getTextModifier = id
+
+-- How we can have multiple modifiers chained
+instance (TextModifier x, TextModifier xs) => TextModifier (x ': xs) where
+  getTextModifier = getTextModifier @xs . getTextModifier @x
+
+instance (KnownSymbol prefix) => TextModifier (StripPrefix prefix) where
+  getTextModifier fld = fromMaybe fld (T.stripPrefix prefixToStrip fld)
+    where
+      prefixToStrip =  T.pack $ symbolVal (Proxy @prefix)
+
+instance (KnownSymbol separator, NonEmptyText separator) => TextModifier (CamelTo separator) where
+  getTextModifier fld = T.pack $ camelTo2 char (T.unpack fld)
+    where
+      char :: Char
+      char = head $ symbolVal (Proxy @separator)
+      camelTo2 :: Char -> String -> String
+      camelTo2 c text = map toLower . go2 $ go1 text
+          where go1 "" = ""
+                go1 (x:u:l:xs) | isUpper u && isLower l = x : c : u : l : go1 xs
+                go1 (x:xs) = x : go1 xs
+                go2 "" = ""
+                go2 (l:u:xs) | isLower l && isUpper u = l : c : u : go2 xs
+                go2 (x:xs) = x : go2 xs
+
 
 class GetName name where
   getName :: Text

--- a/test/GenericsSpec.hs
+++ b/test/GenericsSpec.hs
@@ -31,7 +31,7 @@ data Apple
 data Endpoint = Endpoint
   { enpID :: UUID,
     enpProjectId :: UUID,
-    endRequestHashes :: Vector Text
+    enpRequestHashes :: Vector Text
   }
   deriving (Show, Generic)
   deriving (Entity)

--- a/test/GenericsSpec.hs
+++ b/test/GenericsSpec.hs
@@ -6,7 +6,6 @@ module GenericsSpec where
 import Data.Text
 import Data.UUID
 import Data.Vector
-import Database.PostgreSQL.Entity.Internal.QQ (field)
 import Database.PostgreSQL.Entity.Internal.Unsafe (Field (Field))
 import Database.PostgreSQL.Entity.Types
 import GHC.Generics
@@ -28,14 +27,14 @@ data Apple
   deriving (Entity)
     via (GenericEntity '[TableName "apples"] Apple)
 
-data Endpoint = Endpoint
-  { enpID :: UUID,
-    enpProjectId :: UUID,
-    enpRequestHashes :: Vector Text
-  }
-  deriving (Show, Generic)
+data Endpoint
+  = Endpoint { enpID            :: UUID
+             , enpProjectId     :: UUID
+             , enpRequestHashes :: Vector Text
+             }
+  deriving (Generic, Show)
   deriving (Entity)
-    via (GenericEntity '[TableName "apis.endpoints", PrimaryKey "id", StripPrefix "enp"] Endpoint)
+    via (GenericEntity '[TableName "apis.endpoints", PrimaryKey "id", FieldModifiers '[StripPrefix "enp", CamelToSnake]] Endpoint)
 
 spec :: Spec
 spec = describe "Ensure generically-derived instances with no options are correct" $ do

--- a/test/GenericsSpec.hs
+++ b/test/GenericsSpec.hs
@@ -4,6 +4,8 @@
 module GenericsSpec where
 
 import Data.Text
+import Data.UUID
+import Data.Vector
 import Database.PostgreSQL.Entity.Internal.QQ (field)
 import Database.PostgreSQL.Entity.Internal.Unsafe (Field (Field))
 import Database.PostgreSQL.Entity.Types
@@ -26,6 +28,15 @@ data Apple
   deriving (Entity)
     via (GenericEntity '[TableName "apples"] Apple)
 
+data Endpoint = Endpoint
+  { enpID :: UUID,
+    enpProjectId :: UUID,
+    endRequestHashes :: Vector Text
+  }
+  deriving (Show, Generic)
+  deriving (Entity)
+    via (GenericEntity '[TableName "apis.endpoints", PrimaryKey "id", StripPrefix "enp"] Endpoint)
+
 spec :: Spec
 spec = describe "Ensure generically-derived instances with no options are correct" $ do
   it "TestType has the expected table name" $ do
@@ -40,3 +51,5 @@ spec = describe "Ensure generically-derived instances with no options are correc
     tableName @Apple `shouldBe` "apples"
   it "Apple has the expected fields" $ do
     fields @Apple `shouldBe` [[field| this_field |], [field| that_field |]]
+  it "Prefix stripping works" $ do
+    fields @Endpoint `shouldBe` [[field| id |], [field| project_id |], [field| request_hashes |]]


### PR DESCRIPTION
Fix https://github.com/tchoutri/pg-entity/issues/24

This PR adds the `FieldModifiers` deriving option, which takes multiple modifiers:
  * `StripPrefix (prefix :: Symbol)`: You can remove a certain prefix from your field names
  * `CamelTo (separator :: Symbol)` and its variants, `CamelToSnake` and `CamelToKebab`: Transform field names written
  in CamelCase to snake\_case, kebab-case, or with a custom separator.