### PR TITLE
Do not take the first field as the primary key when the primary key is manually specified, in generic deriving.

### DIFF
--- a/pg-entity.cabal
+++ b/pg-entity.cabal
@@ -124,3 +124,4 @@ test-suite entity-test
     , tmp-postgres
     , uuid
     , vector
+    , aeson

--- a/src/Database/PostgreSQL/Entity.hs
+++ b/src/Database/PostgreSQL/Entity.hs
@@ -240,7 +240,7 @@ _select = textToQuery $ "SELECT " <> expandQualifiedFields @e <> " FROM " <> get
 -- __Examples__
 --
 -- >>> _selectWithFields @BlogPost [ [field| blogpost_id |], [field| created_at |] ]
--- "SELECT blogposts.\"blogpost_id\", blogposts.\"created_at\" FROM \"blogposts\""
+-- "SELECT \"blogposts\".\"blogpost_id\", \"blogposts\".\"created_at\" FROM \"\"blogposts\"\""
 --
 -- @since 0.0.1.0
 _selectWithFields :: forall e. Entity e => Vector Field -> Query
@@ -307,7 +307,7 @@ _selectWhereNull fs = _select @e <> textToQuery (" WHERE " <> isNull fs)
 -- | Produce a SELECT statement where the given field is checked aginst the provided array of values .
 --
 -- >>> _selectWhereIn @BlogPost [field| title |] [ "Unnamed", "Mordred's Song" ]
--- SELECT blogposts."blogpost_id", blogposts."author_id", blogposts."uuid_list", blogposts."title", blogposts."content", blogposts."created_at" FROM "blogposts" WHERE "title" IN ('Unnamed', 'Mordred''s Song')
+-- "SELECT blogposts.\"blogpost_id\", blogposts.\"author_id\", blogposts.\"uuid_list\", blogposts.\"title\", blogposts.\"content\", blogposts.\"created_at\" FROM \"blogposts\" WHERE \"title\" IN ('Unnamed', 'Mordred''s Song')"
 --
 -- @since 0.0.2.0
 
@@ -346,7 +346,7 @@ _innerJoin f = textToQuery $ " INNER JOIN " <> getTableName @e
 -- __Examples__
 --
 -- >>> _joinSelectWithFields @BlogPost @Author [ [field| title |] ] [ [field| name |] ]
--- "SELECT blogposts.\"title\", authors.\"name\" FROM \"blogposts\" INNER JOIN \"authors\" USING(author_id)"
+-- "SELECT \"blogposts\".\"title\", \"authors\".\"name\" FROM \"blogposts\" INNER JOIN \"authors\" USING(author_id)"
 --
 -- @since 0.0.1.0
 _joinSelectWithFields :: forall e1 e2. (Entity e1, Entity e2)
@@ -448,7 +448,7 @@ _delete = textToQuery ("DELETE FROM " <> getTableName @e) <> _where @e [primaryK
 -- __Examples__
 --
 -- >>> _deleteWhere @BlogPost [[field| title |], [field| created_at |]]
--- "DELETE FROM blogposts WHERE \"title\" = ? AND \"created_at\" = ?"
+-- "DELETE FROM \"blogposts\" WHERE \"title\" = ? AND \"created_at\" = ?"
 --
 -- @since 0.0.1.0
 _deleteWhere :: forall e. Entity e => Vector Field -> Query

--- a/src/Database/PostgreSQL/Entity/Internal.hs
+++ b/src/Database/PostgreSQL/Entity/Internal.hs
@@ -80,7 +80,7 @@ quoteName n = "\"" <> n <> "\""
 -- __Examples__
 --
 -- >>> literal "meow."
--- "\'meow.\'"
+-- "'meow.'"
 --
 -- @since 0.0.2.0
 literal :: Text -> Text

--- a/src/Database/PostgreSQL/Entity/Types.hs
+++ b/src/Database/PostgreSQL/Entity/Types.hs
@@ -52,12 +52,12 @@ import qualified Data.Text as T
 import qualified Data.Text.Manipulate as T
 import Data.Vector (Vector)
 import qualified Data.Vector as V
+import qualified Data.Vector as Vector
 import Database.PostgreSQL.Entity.Internal.QQ (field)
 import Database.PostgreSQL.Entity.Internal.Unsafe (Field (Field))
 import Database.PostgreSQL.Simple.ToRow (ToRow (..))
 import GHC.Generics
 import GHC.TypeLits
-import qualified Data.Vector as Vector
 
 -- | An 'Entity' stores the following information about the structure of a database table:
 --
@@ -96,10 +96,10 @@ class Entity e where
     where
       primMod = primaryKeyModifiers defaultEntityOptions
       fs = getField @(Rep e) defaultEntityOptions
-      newPrimaryKey = 
+      newPrimaryKey =
         case Vector.find (\(Field name _type) -> name == primMod name) fs of
           Nothing -> Field (primMod "") Nothing
-          Just f -> f
+          Just f  -> f
   -- | The fields of the table.
   fields :: Vector Field
   default fields :: (GetFields (Rep e)) => Vector Field
@@ -178,10 +178,10 @@ instance (EntityOptions t, GetTableName (Rep e), GetFields (Rep e)) => Entity (G
     where
       primMod = primaryKeyModifiers (entityOptions @t)
       fs = getField @(Rep e) (entityOptions @t)
-      newPrimaryKey = 
+      newPrimaryKey =
         case Vector.find (\(Field name _type) -> name == primMod name) fs of
           Nothing -> Field (primMod "") Nothing
-          Just f -> f
+          Just f  -> f
 
   fields = getField @(Rep e) (entityOptions @t)
 

--- a/src/Database/PostgreSQL/Entity/Types.hs
+++ b/src/Database/PostgreSQL/Entity/Types.hs
@@ -57,6 +57,7 @@ import Database.PostgreSQL.Entity.Internal.Unsafe (Field (Field))
 import Database.PostgreSQL.Simple.ToRow (ToRow (..))
 import GHC.Generics
 import GHC.TypeLits
+import qualified Data.Vector as Vector
 
 -- | An 'Entity' stores the following information about the structure of a database table:
 --
@@ -91,9 +92,14 @@ class Entity e where
   -- | The name of the primary key for the table.
   primaryKey :: Field
   default primaryKey :: (GetFields (Rep e)) => Field
-  primaryKey = Field (primMod name) typ
-    where primMod = primaryKeyModifiers defaultEntityOptions
-          Field name typ = V.head $ getField @(Rep e) defaultEntityOptions
+  primaryKey = newPrimaryKey
+    where
+      primMod = primaryKeyModifiers defaultEntityOptions
+      fs = getField @(Rep e) defaultEntityOptions
+      newPrimaryKey = 
+        case Vector.find (\(Field name _type) -> name == primMod name) fs of
+          Nothing -> Field (primMod "") Nothing
+          Just f -> f
   -- | The fields of the table.
   fields :: Vector Field
   default fields :: (GetFields (Rep e)) => Vector Field
@@ -168,9 +174,14 @@ instance (EntityOptions t, GetTableName (Rep e), GetFields (Rep e)) => Entity (G
 
   schema = schemaModifier (entityOptions @t)
 
-  primaryKey = Field (primMod name) typ
-    where primMod = primaryKeyModifiers defaultEntityOptions
-          Field name typ = V.head $ getField @(Rep e) (entityOptions @t)
+  primaryKey = newPrimaryKey
+    where
+      primMod = primaryKeyModifiers (entityOptions @t)
+      fs = getField @(Rep e) (entityOptions @t)
+      newPrimaryKey = 
+        case Vector.find (\(Field name _type) -> name == primMod name) fs of
+          Nothing -> Field (primMod "") Nothing
+          Just f -> f
 
   fields = getField @(Rep e) (entityOptions @t)
 
@@ -183,7 +194,12 @@ data Options
             }
 
 defaultEntityOptions :: Options
-defaultEntityOptions = Options T.toSnake Nothing T.toSnake T.toSnake
+defaultEntityOptions = Options
+  { tableNameModifiers = T.toSnake
+  , schemaModifier = Nothing
+  , primaryKeyModifiers = T.toSnake
+  , fieldModifiers = T.toSnake
+  }
 
 -- | Type-level options for Deriving Via
 class EntityOptions xs where

--- a/test/GenericsSpec.hs
+++ b/test/GenericsSpec.hs
@@ -14,6 +14,13 @@ import GHC.Generics
 import Test.Tasty
 import Utils
 import qualified Utils as U
+import Data.Time
+import Database.PostgreSQL.Simple
+import Database.PostgreSQL.Transact
+import Data.Aeson
+import Database.PostgreSQL.Simple.ToField
+import Database.PostgreSQL.Simple.FromField
+import Database.PostgreSQL.Entity
 
 data TestType
   = Test { fieldOne   :: Int
@@ -31,14 +38,57 @@ data Apple
   deriving (Entity)
     via (GenericEntity '[TableName "apples"] Apple)
 
-data Endpoint
-  = Endpoint { enpID            :: UUID
-             , enpProjectId     :: UUID
-             , enpRequestHashes :: Vector Text
-             }
-  deriving (Generic, Show)
-  deriving (Entity)
+data Project = Project
+  { createdAt :: ZonedTime,
+    updatedAt :: ZonedTime,
+    deletedAt :: Maybe ZonedTime,
+    active :: Bool,
+    id :: Int,
+    title :: Text,
+    description :: Text,
+    hosts :: Vector Text
+  }
+  deriving (Show, Generic)
+  deriving anyclass (FromRow, ToRow)
+  deriving
+    Entity
+    via (GenericEntity '[Schema "projects", TableName "projects", PrimaryKey "id", FieldModifiers '[CamelToSnake]] Project)
+
+
+newtype ProjectId = ProjectId UUID
+  deriving (Show, Eq, ToField, FromField)
+    via UUID
+
+newtype EndpointId = EndpointId UUID
+  deriving (Show, Eq, ToField, FromField)
+    via UUID
+
+data Endpoint = Endpoint
+  { enpcreatedAt :: ZonedTime,
+    enpupdatedAt :: ZonedTime,
+    enpprojectId :: ProjectId,
+    enpid :: EndpointId,
+    enpurlPath :: Text,
+    enpurlParams :: Value,
+    enpmethod :: Text,
+    enphosts :: Vector Text,
+    enprequestHashes :: Vector Text,
+    enpresponseHashes :: Vector Text,
+    enpqueryparamHashes :: Vector Text
+  }
+  deriving (Show, Generic)
+  deriving anyclass (FromRow, ToRow)
+  deriving
+    (Entity)
     via (GenericEntity '[TableName "endpoints", Schema "apis", PrimaryKey "id", FieldModifiers '[StripPrefix "enp", CamelToSnake]] Endpoint)
+
+
+endpointsByProject :: ProjectId -> DBT IO (Vector Endpoint)
+endpointsByProject pid = selectManyByField @Endpoint [field| project_id |] (Only pid)
+
+endpointById :: EndpointId -> DBT IO (Maybe Endpoint)
+endpointById eId = selectById @Endpoint (Only eId)
+
 
 spec :: TestM TestTree
 spec = testThese "Generic deriving tests"
@@ -51,41 +101,45 @@ spec = testThese "Generic deriving tests"
   , testThis "Prefix stripping works" testPrefixStrippingWorks
   , testThis "Explicit schema works" testExplicitSchemaWorks
   , testThis "Generically derived schema works" testGenericallyDerivedSchema
+  , testThis "Derived primary key is not necessarily the first field" testDerivePrimaryKey
   ]
-
 
 testExpectedTableName :: TestM ()
 testExpectedTableName =
-    U.assertEqual (tableName @TestType) "test_type"
+    U.assertEqual "test_type" (tableName @TestType)
 
 testExpectedFieldList :: TestM ()
 testExpectedFieldList =
-    U.assertEqual (fields @TestType)  [[field| field_one |], [field| field_two |], [field| field_three |]]
+    U.assertEqual  [[field| field_one |], [field| field_two |], [field| field_three |]] (fields @TestType)
 
 testExpectedPrimaryKey :: TestM ()
 testExpectedPrimaryKey =
-    U.assertEqual (primaryKey @TestType) (Field "field_one" Nothing)
+    U.assertEqual (Field "field_one" Nothing) (primaryKey @TestType)
 
 testInferredPrimaryKey :: TestM ()
 testInferredPrimaryKey =
-    U.assertEqual (primaryKey @Apple) (Field "this_field" Nothing)
+    U.assertEqual (Field "this_field" Nothing) (primaryKey @Apple) 
 
 testSpecifiedTableName :: TestM ()
 testSpecifiedTableName =
-    U.assertEqual (tableName @Apple) "apples"
+    U.assertEqual "apples" (tableName @Apple) 
 
 testInferredFields :: TestM ()
 testInferredFields =
-    U.assertEqual (fields @Apple) [[field| this_field |], [field| that_field |]]
+    U.assertEqual [[field| this_field |], [field| that_field |]] (fields @Apple) 
 
 testPrefixStrippingWorks :: TestM ()
 testPrefixStrippingWorks =
-  U.assertEqual (fields @Endpoint) [[field| id |], [field| project_id |], [field| request_hashes |]]
+  U.assertEqual (fields @Endpoint) [[field| created_at |],[field| updated_at |],[field| project_id |],[field| id |],[field| url_path |],[field| url_params |],[field| method |],[field| hosts |],[field| request_hashes |],[field| response_hashes |],[field| queryparam_hashes |]]
 
 testExplicitSchemaWorks :: TestM ()
 testExplicitSchemaWorks =
-  U.assertEqual (getTableName @Tags) "public.\"tags\""
+  U.assertEqual "public.\"tags\"" (getTableName @Tags) 
 
 testGenericallyDerivedSchema :: TestM ()
 testGenericallyDerivedSchema =
-  U.assertEqual (getTableName @Endpoint) "apis.\"endpoints\""
+  U.assertEqual "apis.\"endpoints\"" (getTableName @Endpoint) 
+
+testDerivePrimaryKey :: TestM ()
+testDerivePrimaryKey = do
+  U.assertEqual [field| id |] (primaryKey @Endpoint)


### PR DESCRIPTION
Fix #32