### PR TITLE
Disable logging when in prod mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix primary key detection in generic deriving
 * Remove `withPool'`.
 * When using `resource-pool-0.3`, the type of `withPool` reflects the removal of `MonadBaseControl` from the upstream.
+* The `prod` Cabal flag is introduced. At this time, it disables the stdout logging of queries
 
 ## 0.0.1.0 -- 2021-11-05
 

--- a/cabal.project
+++ b/cabal.project
@@ -16,6 +16,7 @@ package pg-entity
     "-L /usr/pgsql-14/lib" 
   haddock-options:
     "--optghc=-L /usr/pgsql-14/lib" 
+  -- flags: +prod -- uncomment this to deactivate stdout logging
 
 source-repository-package
     type: git

--- a/pg-entity.cabal
+++ b/pg-entity.cabal
@@ -19,6 +19,13 @@ extra-source-files:
   LICENSE.md
   README.md
 
+flag prod
+  description:
+    This flag enables features for production usage, namely:
+      * Disable logging output
+  default: False
+  manual: True
+
 source-repository head
   type:     git
   location: https://github.com/tchoutri/pg-entity
@@ -93,6 +100,9 @@ library
     , uuid              ^>= 1.3
     , vector            ^>= 0.12
     , text-display      ^>= 0.0
+
+  if !flag(prod)
+      cpp-options: -DPROD
 
 test-suite entity-test
   import:         common-extensions


### PR DESCRIPTION
This PR brings a cabal flag "prod" that deactivates stdout logging of queries when enabled