### PR TITLE
Do not filter out inexistent fields from `_where`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        cabal: ["3.4.0.0", "3.6.2.0", "3.8.0.20220526"]
-        ghc: ["8.8.4", "8.10.7", "9.0.2"]
+        cabal: ["3.4.0.0", "3.6.2.0", "3.8.1.0"]
+        ghc: ["8.8.4", "8.10.7", "9.0.2", "9.2.4"]
     steps:
     - uses: actions/checkout@v3
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ clean: ## Remove compilation artifacts
 repl: ## Start a REPL
 	@cabal repl
 
+watch: ## Reload the code on change
+	@ghcid
+
 test: ## Run the test suite
 	@cabal test
 

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ test: ## Run the test suite
 
 lint: ## Run the code linter (HLint)
 	@find test src -name "*.hs" | xargs -P $(PROCS) -I {} hlint --refactor-options="-i" --refactor {}
-	@cabal-fmt -i *.cabal
 
 style: ## Run the code styler (stylish-haskell)
 	@find test src example -name "*.hs" | xargs -P $(PROCS) -I {} fourmolu -q --mode inplace {}
+	@cabal-fmt -i *.cabal
 
 docs-build: ## Generate the documentation
 	@cd docs; mkdocs build

--- a/cabal.project
+++ b/cabal.project
@@ -17,3 +17,4 @@ package pg-entity
   haddock-options:
     "--optghc=-L /usr/pgsql-14/lib" 
   -- flags: +prod -- uncomment this to deactivate stdout logging
+allow-newer: all

--- a/pg-entity.cabal
+++ b/pg-entity.cabal
@@ -13,7 +13,7 @@ maintainer:         Théophile Choutri
 category:           Database
 license:            MIT
 build-type:         Simple
-tested-with:        GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.3
+tested-with:        GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.4
 extra-source-files:
   CHANGELOG.md
   LICENSE.md

--- a/src/Database/PostgreSQL/Entity.hs
+++ b/src/Database/PostgreSQL/Entity.hs
@@ -12,70 +12,69 @@
 --  A PostgreSQL database layer that does not get in your way.
 --
 --  See the "Database.PostgreSQL.Entity.Internal.BlogPost" module for an example of a data-type implementing the 'Entity' typeclass.
-module Database.PostgreSQL.Entity
-  ( -- * The /Entity/ Typeclass
-    Entity (..)
+module Database.PostgreSQL.Entity (
+  -- * The /Entity/ Typeclass
+  Entity (..),
 
-    -- * Associated Types
-  , Field
+  -- * Associated Types
+  Field,
 
-    -- * High-level API
-    -- $highlevel
-  , selectById
-  , selectOneByField
-  , selectManyByField
-  , selectWhereNotNull
-  , selectWhereNull
-  , selectOneWhereIn
-  , joinSelectById
-  , joinSelectOneByField
-  , selectOrderBy
+  -- * High-level API
+  -- $highlevel
+  selectById,
+  selectOneByField,
+  selectManyByField,
+  selectWhereNotNull,
+  selectWhereNull,
+  selectOneWhereIn,
+  joinSelectById,
+  joinSelectOneByField,
+  selectOrderBy,
 
-    -- ** Insertion
-  , insert
-  , insertMany
-  , upsert
+  -- ** Insertion
+  insert,
+  insertMany,
+  upsert,
 
-    -- ** Update
-  , update
-  , updateFieldsBy
+  -- ** Update
+  update,
+  updateFieldsBy,
 
-    -- ** Deletion
-  , delete
-  , deleteByField
+  -- ** Deletion
+  delete,
+  deleteByField,
 
-    -- * SQL Combinators API
+  -- * SQL Combinators API
 
-    -- ** Selection
-  , _select
-  , _selectWithFields
-  , _where
-  , _selectWhere
-  , _selectWhereNotNull
-  , _selectWhereNull
-  , _selectWhereIn
-  , _joinSelect
-  , _innerJoin
-  , _joinSelectWithFields
-  , _joinSelectOneByField
+  -- ** Selection
+  _select,
+  _selectWithFields,
+  _where,
+  _selectWhere,
+  _selectWhereNotNull,
+  _selectWhereNull,
+  _selectWhereIn,
+  _joinSelect,
+  _innerJoin,
+  _joinSelectWithFields,
+  _joinSelectOneByField,
 
-    -- ** Insertion
-  , _insert
-  , _onConflictDoUpdate
+  -- ** Insertion
+  _insert,
+  _onConflictDoUpdate,
 
-    -- ** Update
-  , _update
-  , _updateBy
-  , _updateFields
-  , _updateFieldsBy
+  -- ** Update
+  _update,
+  _updateBy,
+  _updateFields,
+  _updateFieldsBy,
 
-    -- ** Deletion
-  , _delete
-  , _deleteWhere
-  , _orderBy
-  , _orderByMany
-  )
-where
+  -- ** Deletion
+  _delete,
+  _deleteWhere,
+  _orderBy,
+  _orderByMany,
+) where
 
 import Control.Monad (void)
 import Control.Monad.IO.Class (MonadIO)

--- a/src/Database/PostgreSQL/Entity/DBT.hs
+++ b/src/Database/PostgreSQL/Entity/DBT.hs
@@ -9,18 +9,17 @@
 --  Stability   : stable
 --
 --  The 'Database.PostgreSQL.Transact.DBT' plumbing module to handle database queries and pools
-module Database.PostgreSQL.Entity.DBT
-  ( mkPool
-  , withPool
-  , execute
-  , executeMany
-  , query
-  , query_
-  , queryOne
-  , queryOne_
-  , QueryNature (..)
-  )
-where
+module Database.PostgreSQL.Entity.DBT (
+  mkPool,
+  withPool,
+  execute,
+  executeMany,
+  query,
+  query_,
+  queryOne,
+  queryOne_,
+  QueryNature (..),
+) where
 
 #ifdef PROD
 #else

--- a/src/Database/PostgreSQL/Entity/Internal.hs
+++ b/src/Database/PostgreSQL/Entity/Internal.hs
@@ -11,32 +11,31 @@
 --  Internal helpers used to implement the high-level API and SQL combinators.
 --
 --  You can re-use those building blocks freely to create your own wrappers.
-module Database.PostgreSQL.Entity.Internal
-  ( -- * Helpers
-    isNotNull
-  , isNull
-  , isIn
-  , inParens
-  , quoteName
-  , literal
-  , getTableName
-  , getFieldName
-  , getPrimaryKey
-  , prefix
-  , expandFields
-  , expandQualifiedFields
-  , expandQualifiedFields'
-  , qualifyField
-  , qualifyFields
-  , placeholder
-  , placeholder'
-  , generatePlaceholders
-  , textToQuery
-  , queryToText
-  , intercalateVector
-  , renderSortExpression
-  )
-where
+module Database.PostgreSQL.Entity.Internal (
+  -- * Helpers
+  isNotNull,
+  isNull,
+  isIn,
+  inParens,
+  quoteName,
+  literal,
+  getTableName,
+  getFieldName,
+  getPrimaryKey,
+  prefix,
+  expandFields,
+  expandQualifiedFields,
+  expandQualifiedFields',
+  qualifyField,
+  qualifyFields,
+  placeholder,
+  placeholder',
+  generatePlaceholders,
+  textToQuery,
+  queryToText,
+  intercalateVector,
+  renderSortExpression,
+) where
 
 import Data.String (fromString)
 import Data.Text (Text, unpack)

--- a/src/Database/PostgreSQL/Entity/Internal/Unsafe.hs
+++ b/src/Database/PostgreSQL/Entity/Internal/Unsafe.hs
@@ -21,10 +21,9 @@
 --
 --  If at all possible, instead use the API provided by
 --  'Database.PostgreSQL.Entity.Types'.
-module Database.PostgreSQL.Entity.Internal.Unsafe
-  ( Field (..)
-  )
-where
+module Database.PostgreSQL.Entity.Internal.Unsafe (
+  Field (..),
+) where
 
 import Data.Kind
 import Data.String

--- a/src/Database/PostgreSQL/Entity/Types.hs
+++ b/src/Database/PostgreSQL/Entity/Types.hs
@@ -12,36 +12,35 @@
 --  Stability   : stable
 --
 --  Types and classes
-module Database.PostgreSQL.Entity.Types
-  ( -- * The /Entity/ Typeclass
-    Entity (..)
+module Database.PostgreSQL.Entity.Types (
+  -- * The /Entity/ Typeclass
+  Entity (..),
 
-    -- * Associated Types
-  , Field
-  , field
-  , fieldName
-  , fieldType
-  , UpdateRow (..)
-  , SortKeyword (..)
+  -- * Associated Types
+  Field,
+  field,
+  fieldName,
+  fieldType,
+  UpdateRow (..),
+  SortKeyword (..),
 
-    -- * Generics
-  , Options (..)
-  , defaultEntityOptions
+  -- * Generics
+  Options (..),
+  defaultEntityOptions,
 
-    -- * DerivingVia Options
-  , GenericEntity (..)
-  , EntityOptions (..)
-  , PrimaryKey
-  , Schema
-  , TableName
-  , FieldModifiers
-  , TextModifier (..)
-  , StripPrefix
-  , CamelTo
-  , CamelToSnake
-  , CamelToKebab
-  )
-where
+  -- * DerivingVia Options
+  GenericEntity (..),
+  EntityOptions (..),
+  PrimaryKey,
+  Schema,
+  TableName,
+  FieldModifiers,
+  TextModifier (..),
+  StripPrefix,
+  CamelTo,
+  CamelToSnake,
+  CamelToKebab,
+) where
 
 import Data.Char
 import Data.Kind

--- a/test/EntitySpec.hs
+++ b/test/EntitySpec.hs
@@ -9,33 +9,33 @@ import Control.Monad.IO.Class
 import Data.Text (Text)
 import qualified Data.UUID as UUID
 import qualified Data.Vector as V
-import Database.PostgreSQL.Entity
-  ( delete
-  , deleteByField
-  , joinSelectOneByField
-  , selectById
-  , selectManyByField
-  , selectOneByField
-  , selectOneWhereIn
-  , selectOrderBy
-  , selectWhereNotNull
-  , selectWhereNull
-  , update
-  , updateFieldsBy
-  , _joinSelectWithFields
-  , _where
-  )
+import Database.PostgreSQL.Entity (
+  delete,
+  deleteByField,
+  joinSelectOneByField,
+  selectById,
+  selectManyByField,
+  selectOneByField,
+  selectOneWhereIn,
+  selectOrderBy,
+  selectWhereNotNull,
+  selectWhereNull,
+  update,
+  updateFieldsBy,
+  _joinSelectWithFields,
+  _where,
+ )
 import Database.PostgreSQL.Entity.DBT (QueryNature (..), query)
-import Database.PostgreSQL.Entity.Internal.BlogPost
-  ( Author (..)
-  , AuthorId (..)
-  , BlogPost (..)
-  , bulkInsertAuthors
-  , bulkInsertBlogPosts
-  , insertAuthor
-  , insertBlogPost
-  , upsertBlogPost
-  )
+import Database.PostgreSQL.Entity.Internal.BlogPost (
+  Author (..),
+  AuthorId (..),
+  BlogPost (..),
+  bulkInsertAuthors,
+  bulkInsertBlogPosts,
+  insertAuthor,
+  insertBlogPost,
+  upsertBlogPost,
+ )
 import Database.PostgreSQL.Simple (Only (Only))
 import Database.PostgreSQL.Transact (DBT)
 

--- a/test/EntitySpec.hs
+++ b/test/EntitySpec.hs
@@ -130,7 +130,7 @@ getAllTitlesByAuthorName = do
 
   let q =
         _joinSelectWithFields @BlogPost @Author [[field| title |]] [[field| name |]]
-          <> _where @Author [[field| name |]]
+          <> _where [[field| name |]]
   result <- liftDB (query Select q (Only ("Hansi Kürsch" :: Text)) :: (MonadIO m) => DBT m (Vector (Text, Text)))
   U.assertEqual [("The Script for my requiem", "Hansi Kürsch"), ("Mordred's Song", "Hansi Kürsch")] result
 


### PR DESCRIPTION
PostgreSQL is better at reporting typos than we are.